### PR TITLE
remove intel dcap qpl sym link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN ninja -C build install
 
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal" | tee /etc/apt/sources.list.d/tensorflow-serving.list && curl https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y tensorflow-model-server
+# running apt install restores the symlink for libsgx-dcap-default-qpl, which was removed by the ert base image. Remove it again so we can use the az-dcap-client instead
+RUN rm -rf /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so.1
 
 COPY ./graphene-files/ /graphene/Examples/tensorflow-marblerun/
 WORKDIR /graphene/Examples/tensorflow-marblerun


### PR DESCRIPTION
The ert image we use as a base now contains the default intel qpl. 
Since the azure dcap client will use the intel qpl instead, if it was installed, we rename the sym-link created by the installation from `libdcap_quoteprov.so.1` to `libdcap_quoteprov.so.1.intel`.
However, every time we run `apt install` this sym-link is recreated, which is why we need to manually remove the link at the end of a Dockerfile if we installed any packages.