### PR TITLE
Update MarbleRun spelling

### DIFF
--- a/tf-server-manifest.json
+++ b/tf-server-manifest.json
@@ -28,7 +28,7 @@
                     "--file_system_poll_wait_seconds=10"
                 ],
                 "Files": {
-                    "ssl.cfg": "server_key: '-----BEGIN PRIVATE KEY-----\\n{{ base64 .Marblerun.MarbleCert.Private }}\\n-----END PRIVATE KEY-----'\nserver_cert: '-----BEGIN CERTIFICATE-----\\n{{ base64 .Marblerun.MarbleCert.Cert }}\\n-----END CERTIFICATE-----'\nclient_verify: false",
+                    "ssl.cfg": "server_key: '-----BEGIN PRIVATE KEY-----\\n{{ base64 .MarbleRun.MarbleCert.Private }}\\n-----END PRIVATE KEY-----'\nserver_cert: '-----BEGIN CERTIFICATE-----\\n{{ base64 .MarbleRun.MarbleCert.Cert }}\\n-----END CERTIFICATE-----'\nclient_verify: false",
                     "/dev/attestation/protected_files_key": "{{ hex .Secrets.pfKey }}"
                 }
             }


### PR DESCRIPTION
*Don't merge before new MarbleRun release!!*

Updates the manifest to new MarbleRun spelling, will break the demo without a new MarbleRun release, so please wait before merging.