### PR TITLE
Upgrade to Gramine v1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /premain/build
 RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 RUN make premain-libos
 
-FROM gramineproject/gramine:v1.4 AS release
+FROM gramineproject/gramine:v1.5 AS release
 RUN apt update && \
     apt install -y libssl-dev gnupg software-properties-common wget
 

--- a/gramine-files/tensorflow_model_server.manifest.template
+++ b/gramine-files/tensorflow_model_server.manifest.template
@@ -57,7 +57,7 @@ fs.mounts = [
 # Set the virtual memory size of the SGX enclave. For SGX v1, the enclave
 # size must be specified during signing. If TF-Serving needs more virtual memory
 # than the enclave size, Gramine will not be able to allocate it.
-sgx.enclave_size = "8G"
+sgx.enclave_size = "4G"
 
 # Set the maximum number of enclave threads. For SGX v1, the number of enclave
 # TCSes must be specified during signing, so the application cannot use more


### PR DESCRIPTION
* Fix a problem with v1.4 needing the nonpie option, which was removed in v1.5
* Fix doubled enclave size in gramine manifest

Image available: `ghcr.io/edgelesssys/tensorflow-gramine-marble:gramine-v1.5`